### PR TITLE
Bug fixes and enhancements

### DIFF
--- a/files/changelog.txt
+++ b/files/changelog.txt
@@ -1,3 +1,8 @@
+Release v1.3, a.k.a. "The Bootleg Edition"
+* ModuleScienceAvailabilityIndicator can now specify lowDataColor and unavailableColor sources, and can be constrained to a single experimentID on multi-experiment parts
+* Fix a bug in ModuleScienceDataIndicator that showed dataColor instead of lowDataColor when science data worth zero was stored
+* ModuleReactionWheelIndicator no longer flashes "deprived" warnings when SAS is turned off (prevents false alarms and incorrect readings that were ocurring if fuel ran out or was replenished while SAS was disabled)
+
 Release v1.2, a.k.a. "The Antennas Edition"
 * Add indicators to all antennas, with a random modem-like flicker while transmitting data. Faster transmitters = faster flicker.
 * Fix a bug that caused IndicatorLights-enabled meshes to not work with the thermal overlay (Science Jr. was especially bad).

--- a/files/changelog.txt
+++ b/files/changelog.txt
@@ -1,7 +1,7 @@
 Release v1.3, a.k.a. "The Bootleg Edition"
 * ModuleScienceAvailabilityIndicator can now specify lowDataColor and unavailableColor sources, and can be constrained to a single experimentID on multi-experiment parts
 * Fix a bug in ModuleScienceDataIndicator that showed dataColor instead of lowDataColor when science data worth zero was stored
-* ModuleReactionWheelIndicator no longer flashes "deprived" warnings when SAS is turned off (prevents false alarms and incorrect readings that were ocurring if fuel ran out or was replenished while SAS was disabled)
+* ModuleReactionWheelIndicator no longer flashes "deprived" warnings when SAS is turned off (prevents false alarms and incorrect readings that were ocurring if ElectricCharge ran out or was replenished while SAS was disabled)
 
 Release v1.2, a.k.a. "The Antennas Edition"
 * Add indicators to all antennas, with a random modem-like flicker while transmitting data. Faster transmitters = faster flicker.

--- a/src/ModuleReactionWheelIndicator.cs
+++ b/src/ModuleReactionWheelIndicator.cs
@@ -64,7 +64,7 @@ namespace IndicatorLights
             get
             {
                 Color baseColor = CurrentSource.OutputColor;
-                if (IsDeprived) return BLINK.State ? baseColor : DefaultColor.Off.Value();
+                if (IsDeprived && IsAutopilotActive) return BLINK.State ? baseColor : DefaultColor.Off.Value();
                 return (IsAutopilotActive) ? baseColor : (0.5f * baseColor);
             }
         }
@@ -93,6 +93,12 @@ namespace IndicatorLights
                 for (int i = 0; i < SourceModule.resHandler.inputResources.Count; ++i)
                 {
                     ModuleResource resource = SourceModule.resHandler.inputResources[i];
+
+                    // Temporary code for debugging
+                    //Logging.Log("Reaction wheel " + resource.name + (resource.available ? " available" : " unavailable")
+                    //  + ".  Amount: " + resource.amount + ", currentAmount: " + resource.currentAmount
+                    //  + ", currentRequest: " + resource.currentRequest + ", isDeprived: " + resource.isDeprived);
+
                     // I'm using !available rather than isDeprived, because as far as I can tell, isDeprived is always false
                     if (!resource.available) return true;
                 }

--- a/src/ModuleScienceDataIndicatorBase.cs
+++ b/src/ModuleScienceDataIndicatorBase.cs
@@ -90,6 +90,7 @@ namespace IndicatorLights
                 if ((partialDataSource == null) || (lowDataSource == null)) return dataSource;
                 switch (ScienceFraction)
                 {
+                    case null:
                     case ScienceValue.Fraction.Low:
                         return lowDataSource;
                     case ScienceValue.Fraction.Medium:

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.2.1.0")]
+[assembly: AssemblyFileVersion("1.2.1.0")]


### PR DESCRIPTION
- Add optional lowDataColor, unavailableColor and experimentID fields to ModuleScienceAvailabilityIndicator.  Not sure if lowDataColor and unavailableColor are really both needed; but I wanted to be able to be alerted when even a little bit of new science is available (to scoop up every last ounce), and to distinguish between "some" and "none".
- Fix a bug in ModuleScienceDataIndicator that showed dataColor instead of lowDataColor when the latter was specified and science data worth zero was stored (due to null case not being handled).
- Fix a bug with ModuleReactionWheelIndicator by no longer indicating "deprived" when SAS is turned off.  Prevents false alarms and incorrect readings that were occurring if fuel ran out or was replenished while SAS was disabled.
- Set DLL version metadata.

Please feel free to butcher, reject or refactor these changes as you see fit.  I did some testing tonight before I ran out of steam.
