### PR TITLE
Fix missing title field in agents.cfg

### DIFF
--- a/files/Agencies/Agents.cfg
+++ b/files/Agencies/Agents.cfg
@@ -1,6 +1,7 @@
 AGENT
 {
   name = Blinkenlights LLC
+  title = Blinkenlights LLC
   
   description = Give us your tired old technology and we'll glitz it up with distracting glowy things!
   


### PR DESCRIPTION
Missing title field causes an error "Input is null for field 'agent' in config node 'CONTRACT'"